### PR TITLE
Make twig global variables available in datasource theme blocks

### DIFF
--- a/Tests/Twig/Extension/DataSourceExtensionTest.php
+++ b/Tests/Twig/Extension/DataSourceExtensionTest.php
@@ -48,6 +48,7 @@ class DataSourceExtensionTest extends \PHPUnit_Framework_TestCase
         $twig = new \Twig_Environment($loader);
         $twig->addExtension(new TranslationExtension(new StubTranslator()));
         $twig->addExtension(new FormExtension($renderer));
+        $twig->addGlobal('global_var', 'global_value');
         $this->twig = $twig;
 
         $this->extension = new DataSourceExtension($this->getContainer(), 'datasource.html.twig');
@@ -128,7 +129,8 @@ class DataSourceExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('displayBlock')
             ->with('datasource_filter', array(
                 'datasource' => $datasourceView,
-                'vars' => array()
+                'vars' => array(),
+                'global_var' => 'global_value'
             ))
             ->will($this->returnValue(true));
 
@@ -175,7 +177,8 @@ class DataSourceExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('displayBlock')
             ->with('datasource_filter', array(
                 'datasource' => $datasourceView,
-                'vars' => array()
+                'vars' => array(),
+                'global_var' => 'global_value'
             ))
             ->will($this->returnValue(true));
 

--- a/Twig/Extension/DataSourceExtension.php
+++ b/Twig/Extension/DataSourceExtension.php
@@ -45,17 +45,17 @@ class DataSourceExtension extends \Twig_Extension
     private $additional_parameters;
 
     /**
-     * @var Twig_TemplateInterface
+     * @var \Twig_TemplateInterface
      */
     private $baseTemplate;
 
     /**
-     * @var ContainerInterace
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
      */
     private $container;
 
     /**
-     * @var Twig_Environment
+     * @var \Twig_Environment
      */
     private $environment;
 
@@ -467,6 +467,8 @@ class DataSourceExtension extends \Twig_Extension
     private function renderTheme(DataSourceViewInterface $view, array $contextVars = array(), $availableBlocks = array())
     {
         $templates = $this->getTemplates($view);
+
+        $contextVars = $this->environment->mergeGlobals($contextVars);
 
         ob_start();
 


### PR DESCRIPTION
It closes issue #38 
